### PR TITLE
Making title and summary translatable

### DIFF
--- a/ProcessChangelog.module
+++ b/ProcessChangelog.module
@@ -27,8 +27,8 @@ class ProcessChangelog extends Process implements ConfigurableModule {
      */
     public static function getModuleInfo() {
         return array(
-            'title' => 'Changelog',
-            'summary' => 'Keep track of changes (edits, removals, additions etc.)',
+            'title' => __('Changelog'),
+            'summary' => __('Keep track of changes (edits, removals, additions etc.)'),
             'href' => 'http://modules.processwire.com/modules/process-changelog/',
             'author' => 'Teppo Koivula',
             'version' => 103,


### PR DESCRIPTION
I needed to translate the module title and summary for a project I'm working on with Processwire. This patch makes them translatable.
