### PR TITLE
Adding filter for system pages

### DIFF
--- a/ProcessChangelog.module
+++ b/ProcessChangelog.module
@@ -213,7 +213,6 @@ class ProcessChangelog extends Process implements ConfigurableModule {
         );
         // default value (taken from the config option)
         if ( ! $this->input->get->system_pages ) {
-            var_dump('defaulting');
             $this->input->get->system_pages = $this->system_pages;
         }
         foreach ($this->input->get as $key => $value) {


### PR DESCRIPTION
At the moment the changelog show changes on everything, including "system" pages (such as users, languages, roles, etc.). In the project I'm working on, the admin user is (most of the time) not interested by these changes and wants to be able to filter the list to show only changes on user-created pages.

This patch implements this functionnality by adding a filter and a config option to select the default behavior.
