### PR TITLE
new version of fontawesome cdn

### DIFF
--- a/ProcessChangelog.module
+++ b/ProcessChangelog.module
@@ -377,7 +377,7 @@ class ProcessChangelog extends Process implements ConfigurableModule {
 
         // make sure that we have a newish version of Font-Awesome loaded
         if (version_compare($this->config->version, '3.0.18', '<')) {
-            $this->config->styles->add('//maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css');
+            $this->config->styles->add('//cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.1/css/fontawesome.min.css');
         }
 
         // render filters (this has to be done here because certain filter


### PR DESCRIPTION
https://www.bootstrapcdn.com/fontawesome/ is now referring to version 6.2.1 and a new cdn url (at cdn.jsdeliver.net instead of maxcdn.bootstrapcdn.com

All icons used in the modules is still available in the new version, so no other changes needed for this.